### PR TITLE
Fix Test_Motor.py GPIO error, and add cleanup to Stepper_Test.py

### DIFF
--- a/Stepper_Test.py
+++ b/Stepper_Test.py
@@ -1,11 +1,18 @@
+import RPi.GPIO as GPIO                        #Import GPIO library
 import PiMotor
 import time
 
 m1 = PiMotor.Stepper("STEPPER1")
 
 # Rotate Stepper 1 Contiously in forward/backward direction
-while True:
-    m1.forward(0.1,10)  # Delay and rotations
-    time.sleep(2)
-    m1.backward(0.1,10)
-    time.sleep(2)
+
+try:
+    while True:
+        m1.forward(0.1,10)  # Delay and rotations
+        time.sleep(2)
+        m1.backward(0.1,10)
+        time.sleep(2)
+
+
+except KeyboardInterrupt:
+    GPIO.cleanup()

--- a/Test_Motor.py
+++ b/Test_Motor.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import RPi.GPIO as GPIO                        #Import GPIO library
 import PiMotor
 import time
 


### PR DESCRIPTION
Pressing CTRL + C to end Test_Motor.py caused an error that GPIO was not defined. Additionally, GPIO would remain in its previous state prior to interrupt. Importing GPIO in Test_Motor.py clears the error and executes the cleanup successfully.

The keyboard interrupt was not added to Stepper_Test.py. Interrupting execution left the GPIO in its previous state prior to interrupt. Importing GPIO and adding the `try: ... except:` block with `GPIO.cleanup()` executes the GPIO cleanup.